### PR TITLE
Adds possibility to call apiCallback directly if external parameter is set to true

### DIFF
--- a/src/ApiMailAdapter.js
+++ b/src/ApiMailAdapter.js
@@ -16,7 +16,7 @@ class ApiMailAdapter extends MailAdapter {
   constructor(options) {
 
     // Get parameters
-    const { sender, templates, thirdParty = false, apiCallback } = options || {};
+    const { sender, templates, external = false, apiCallback } = options || {};
 
     // Ensure required parameters are set
     if (!sender) {
@@ -45,7 +45,7 @@ class ApiMailAdapter extends MailAdapter {
     this.sender = sender;
     this.templates = templates;
     this.apiCallback = apiCallback;
-    this.thirdParty = thirdParty;
+    this.external = external;
   }
 
   /**
@@ -62,7 +62,7 @@ class ApiMailAdapter extends MailAdapter {
       link,
       appName,
       user,
-      thirdParty: this.thirdParty
+      external: this.external
     });
   }
 
@@ -80,7 +80,7 @@ class ApiMailAdapter extends MailAdapter {
       link,
       appName,
       user,
-      thirdParty: this.thirdParty
+      external: this.external
     });
   }
 
@@ -96,10 +96,10 @@ class ApiMailAdapter extends MailAdapter {
    * @param {Object} [placeholders] The template placeholders.
    * @param {Object} [extra] Any additional variables to pass to the mail provider API.
    * @param {Parse.User} [user] The Parse User that the is the recipient of the email.
-   * @param {Boolean} [thirdParty] Whether or not the email is to be handled externally by a thirdParty - overrides the default passed as option during class instantiation.
+   * @param {Boolean} [external] Whether or not the email is to be handled externally by a external - overrides the default passed as option during class instantiation.
    * @returns {Promise<Any>} The mail provider API response.
    */
-  async sendMail({ sender, recipient, subject, text, html, templateName, placeholders, extra, user, thirdParty}) {
+  async sendMail({ sender, recipient, subject, text, html, templateName, placeholders, extra, user, external}) {
     return await this._sendMail({
       sender,
       recipient,
@@ -110,7 +110,7 @@ class ApiMailAdapter extends MailAdapter {
       placeholders,
       extra,
       user,
-      thirdParty,
+      external,
       direct: true
     });
   }
@@ -123,10 +123,10 @@ class ApiMailAdapter extends MailAdapter {
    */
   async _sendMail(email) {
 
-    const thirdParty = email.thirdParty ?? this.thirdParty;
+    const external = email.external ?? this.external;
 
     // If the mail sending feature is to be handled by a third party, then we call the apiCallback directly
-    if (thirdParty){
+    if (external){
       return await this.apiCallback({options:email});
     }
 

--- a/src/ApiMailAdapter.js
+++ b/src/ApiMailAdapter.js
@@ -16,7 +16,7 @@ class ApiMailAdapter extends MailAdapter {
   constructor(options) {
 
     // Get parameters
-    const { sender, templates, apiCallback } = options || {};
+    const { sender, templates, thirdParty = false, apiCallback } = options || {};
 
     // Ensure required parameters are set
     if (!sender) {
@@ -44,7 +44,8 @@ class ApiMailAdapter extends MailAdapter {
     // Set properties
     this.sender = sender;
     this.templates = templates;
-    this.apiCallback = apiCallback
+    this.apiCallback = apiCallback;
+    this.thirdParty = thirdParty;
   }
 
   /**
@@ -60,7 +61,8 @@ class ApiMailAdapter extends MailAdapter {
       templateName: 'passwordResetEmail',
       link,
       appName,
-      user
+      user,
+      thirdParty: this.thirdParty
     });
   }
 
@@ -77,7 +79,8 @@ class ApiMailAdapter extends MailAdapter {
       templateName: 'verificationEmail',
       link,
       appName,
-      user
+      user,
+      thirdParty: this.thirdParty
     });
   }
 
@@ -93,9 +96,10 @@ class ApiMailAdapter extends MailAdapter {
    * @param {Object} [placeholders] The template placeholders.
    * @param {Object} [extra] Any additional variables to pass to the mail provider API.
    * @param {Parse.User} [user] The Parse User that the is the recipient of the email.
+   * @param {Boolean} [thirdParty] Whether or not the email is to be handled externally by a thirdParty - overrides the default passed as option during class instantiation.
    * @returns {Promise<Any>} The mail provider API response.
    */
-  async sendMail({ sender, recipient, subject, text, html, templateName, placeholders, extra, user }) {
+  async sendMail({ sender, recipient, subject, text, html, templateName, placeholders, extra, user, thirdParty}) {
     return await this._sendMail({
       sender,
       recipient,
@@ -106,6 +110,7 @@ class ApiMailAdapter extends MailAdapter {
       placeholders,
       extra,
       user,
+      thirdParty,
       direct: true
     });
   }
@@ -117,6 +122,13 @@ class ApiMailAdapter extends MailAdapter {
    * @returns {Promise} The mail provider API response.
    */
   async _sendMail(email) {
+
+    const thirdParty = email.thirdParty ?? this.thirdParty;
+
+    // If the mail sending feature is to be handled by a third party, then we call the apiCallback directly
+    if (thirdParty){
+      return await this.apiCallback({options:email});
+    }
 
     // Define parameters
     let message;
@@ -195,7 +207,7 @@ class ApiMailAdapter extends MailAdapter {
     const apiData = await this._createApiData({ message, template, placeholders, user });
 
     // Send email
-    return await this.apiCallback(apiData);
+    return await this.apiCallback({...apiData, options:email }); // Pass down original/raw email options to the mail client
   }
 
   /**


### PR DESCRIPTION
The use cases for this PR are as follows: 

- Using a third-party email client like Sendgrid or Mailgun, the apiCallback should be able to receive the payload and locale in addition to the full options that were passed during the call to sendMail to generate the payload and locale.
- Setting or passing an additional parameter [external = true], enables apiCallback to be called directly without prior processing of the payload from local sources. 